### PR TITLE
Fix image pre-loading

### DIFF
--- a/src/components/LoadingScreen/index.tsx
+++ b/src/components/LoadingScreen/index.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react'
 
+import Image from 'next/image'
+
 import { useThreeContext } from '../../contexts/ThreeJSContext'
 import { useUIContext } from '../../contexts/UIContext'
 import Loader from '../../three/experience/Loader'
@@ -21,6 +23,10 @@ const LoadingScreen: React.FC = () => {
   return (
     <Container className={progress === 1 ? 'loaded' : ''}>
       <h2>{Math.round(progress * 10000) / 100}%</h2>
+      <Image src='/images/about.png' alt='about' layout='fill' quality={100} />
+      <Image src='/images/converge.svg' alt='logo' width={300} height={45} />
+      <Image src='/images/map.png' alt='map' height={630} width={1152} />
+      <Image src='/images/team.png' alt='about' layout='fill' quality={100} />
     </Container>
   )
 }

--- a/src/components/LoadingScreen/styles.ts
+++ b/src/components/LoadingScreen/styles.ts
@@ -20,4 +20,9 @@ export const Container = styled.div`
     transition: opacity 0.5s ease-in-out;
     transition-delay: 0.5s;
   }
+
+  img {
+    position: fixed;
+    opacity: 0;
+  }
 `


### PR DESCRIPTION
Muito bizarro?
Tem que ser exatamente a mesma tag pro next fazer a mesma query de URL de imagem. Mudando um pouquinho já troca a URL (por exemplo quality `&q=100` vs default `&q=75`)